### PR TITLE
add missing dash to utf-8 in meta charset

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-	<meta charset='utf8'>
+	<meta charset='utf-8'>
 	<meta name='viewport' content='width=device-width'>
 
 	<title>Sylph Example Site</title>


### PR DESCRIPTION
```diff
-	<meta charset='utf8'>
+	<meta charset='utf-8'>
```

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
https://www.iana.org/assignments/character-sets/character-sets.xhtml
https://tools.ietf.org/html/rfc3629